### PR TITLE
Change project root to `/sindri/`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,7 +40,7 @@ jobs:
             --tag sindrilabs/${{ matrix.image }}:latest \
             --http-probe=false \
             --exclude-pattern '/tmp/*' \
-            --mount "./images/${{ matrix.image }}/:/sindri-project/" \
+            --mount "./images/${{ matrix.image }}/:/sindri/" \
             --exec "./test.sh"
 
       - name: Deploy to DockerHub

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ docker compose build
 
 ### Running Command Containers
 
-This will execute the command container with a bind mount of `images/circom/` at `/sindri-project/` (which is also the current working directory) in the container:
+This will execute the command container with a bind mount of `images/circom/` at `/sindri/` (which is also the current working directory) in the container:
 
 ```bash
 # Replace "circom" with the appropriate command.

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,31 +5,31 @@ services:
     container_name: circom
     image: circom:unoptimized
     build: ./images/circom/
-    working_dir: /sindri-project/
+    working_dir: /sindri/
     volumes:
-      - ./images/circom/:/sindri-project/
+      - ./images/circom/:/sindri/
 
   circomspect:
     container_name: circomspect
     image: circomspect:unoptimized
     build: ./images/circomspect/
-    working_dir: /sindri-project/
+    working_dir: /sindri/
     volumes:
-      - ./images/circomspect/:/sindri-project/
+      - ./images/circomspect/:/sindri/
 
   nargo:
     container_name: nargo
     image: nargo:unoptimized
     build: ./images/nargo/
     platform: linux/amd64
-    working_dir: /sindri-project/
+    working_dir: /sindri/
     volumes:
-      - ./images/nargo/:/sindri-project/
+      - ./images/nargo/:/sindri/
 
   snarkjs:
     container_name: snarkjs
     image: snarkjs:unoptimized
     build: ./images/snarkjs/
-    working_dir: /sindri-project/
+    working_dir: /sindri/
     volumes:
-      - ./images/snarkjs/:/sindri-project/
+      - ./images/snarkjs/:/sindri/

--- a/images/circom/Dockerfile
+++ b/images/circom/Dockerfile
@@ -14,6 +14,6 @@ RUN git clone https://github.com/iden3/circom.git \
     && cargo build --release \
     && cargo install --path circom
 
-WORKDIR /sindri-project/
+WORKDIR /sindri/
 
 ENTRYPOINT ["circom"]

--- a/images/circomspect/Dockerfile
+++ b/images/circomspect/Dockerfile
@@ -14,6 +14,6 @@ RUN git clone https://github.com/trailofbits/circomspect.git \
     && cargo build --release \
     && cargo install --path cli
 
-WORKDIR /sindri-project/
+WORKDIR /sindri/
 
 ENTRYPOINT ["circomspect"]

--- a/images/nargo/Dockerfile
+++ b/images/nargo/Dockerfile
@@ -7,6 +7,6 @@ ENV PATH="/root/.nargo/bin:$PATH"
 RUN noirup
 
 SHELL ["/bin/sh", "-c"]
-WORKDIR /sindri-project/
+WORKDIR /sindri/
 
 ENTRYPOINT ["nargo"]

--- a/images/snarkjs/Dockerfile
+++ b/images/snarkjs/Dockerfile
@@ -3,6 +3,6 @@ FROM node:lts-bookworm-slim
 # Install SnarkJS.
 RUN npm install -g snarkjs@latest
 
-WORKDIR /sindri-project/
+WORKDIR /sindri/
 
 ENTRYPOINT ["snarkjs"]


### PR DESCRIPTION
The `/sindri-project/` name was a little verbose, `/sindri/` is cleaner.
