### PR TITLE
Add production deployment for circomspect

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Build Optimized Image
         run: |
           slim build --target ${{ matrix.image }}:unoptimized \
-            --tag sindrilabs/${{ matrix.image }}:latest \
+            --tag sindrilabs/${{ matrix.image }}:dev \
             --http-probe=false \
             --exclude-pattern '/tmp/*' \
             --mount "./images/${{ matrix.image }}/:/sindri/" \
@@ -45,4 +45,4 @@ jobs:
 
       - name: Deploy to DockerHub
         run: |
-          docker push sindrilabs/${{ matrix.image }}:latest
+          docker push sindrilabs/${{ matrix.image }}:dev

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,14 +4,15 @@ on:
   # Runs on pushes targeting the default branch.
   push:
     branches: ["main"]
-  # TODO: remove me.
-  pull_request:
 
   # Allows you to run this workflow manually from the Actions tab.
   workflow_dispatch:
 
+  schedule:
+    # Runs at 08:00 UTC every day, 3 or 4am Eastern depending on DST.
+    - cron: "0 8 * * *"
+
 jobs:
-  # Single deploy job since we're just deploying.
   deploy:
     strategy:
       matrix:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         include:
           - image: "circomspect"
-          - github_repository: "trailofbits/circomspect"
+            github_repository: "trailofbits/circomspect"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -44,7 +44,7 @@ jobs:
           echo "Building all tags for ${{ matrix.github_repository }}..."
           for tag in $(./scripts/list-tags.sh ${{ matrix.github_repository }}); do
             echo "Freeing up disk space with docker prune..."
-            docker prune --all --force --volumes
+            docker system prune --all --force --volumes
 
             echo "Building ${{ matrix.image }}:${tag}..."
             docker buildx build -f images/${{ matrix.image }}/Dockerfile --build-arg "TAG=${tag}" -t ${{ matrix.image }}:unoptimized --load images/${{ matrix.image }}/

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,6 +4,8 @@ on:
   # Runs on pushes targeting the default branch.
   push:
     branches: ["main"]
+  # TODO: remove me.
+  pull_request:
 
   # Allows you to run this workflow manually from the Actions tab.
   workflow_dispatch:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -43,6 +43,9 @@ jobs:
         run: |
           echo "Building all tags for ${{ matrix.github_repository }}..."
           for tag in $(./scripts/list-tags.sh ${{ matrix.github_repository }}); do
+            echo "Freeing up disk space with docker prune..."
+            docker prune --all --force --volumes
+
             echo "Building ${{ matrix.image }}:${tag}..."
             docker buildx build -f images/${{ matrix.image }}/Dockerfile --build-arg "TAG=${tag}" -t ${{ matrix.image }}:unoptimized --load images/${{ matrix.image }}/
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,60 @@
+name: Build and Deploy Tagged Versions
+
+on:
+  # Runs on pushes targeting the default branch.
+  push:
+    branches: ["main"]
+  # TODO: remove me.
+  pull_request:
+
+  # Allows you to run this workflow manually from the Actions tab.
+  workflow_dispatch:
+
+jobs:
+  # Single deploy job since we're just deploying.
+  deploy:
+    strategy:
+      matrix:
+        include:
+          - image: "circomspect"
+          - github_repository: "trailofbits/circomspect"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Install SlimTookit
+        run: |
+          curl -sL https://raw.githubusercontent.com/slimtoolkit/slim/master/scripts/install-slim.sh | sudo -E bash -
+
+      - name: Build and Deploy Images
+        run: |
+          echo "Building all tags for ${{ matrix.github_repository }}..."
+          for tag in $(./scripts/list-tags.sh ${{ matrix.github_repository }}); do
+            echo "Building ${{ matrix.image }}:${tag}..."
+            docker buildx build -f images/${{ matrix.image }}/Dockerfile --build-arg "TAG=${tag}" -t ${{ matrix.image }}:unoptimized --load images/${{ matrix.image }}/
+
+            echo "Optimizing ${{ matrix.image }}:${tag}..."
+            slim build --target ${{ matrix.image }}:unoptimized \
+              --tag "sindrilabs/${{ matrix.image }}:${tag}" \
+              --tag sindrilabs/${{ matrix.image }}:latest \
+              --http-probe=false \
+              --exclude-pattern '/tmp/*' \
+              --mount "./images/${{ matrix.image }}/:/sindri/" \
+              --exec "./test.sh"
+
+            echo "Publishing ${{ matrix.image }}:${tag}..."
+            docker push "sindrilabs/${{ matrix.image }}:${tag}"
+          done
+
+          echo "Publishing ${{ matrix.image }}:latest..."
+          docker push sindrilabs/${{ matrix.image }}:latest

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,8 +4,6 @@ on:
   # Runs on pushes targeting the default branch.
   push:
     branches: ["main"]
-  # TODO: remove me.
-  pull_request:
 
   # Allows you to run this workflow manually from the Actions tab.
   workflow_dispatch:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,10 +1,6 @@
 name: Build Dev Images
 
 on:
-  push:
-    branches: ["main"]
-    tags:
-      - "v*"
   pull_request:
 
 jobs:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,4 +1,4 @@
-name: Build Images
+name: Build Dev Images
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  pr:
     strategy:
       matrix:
         image: ["circom", "circomspect", "nargo", "snarkjs"]

--- a/images/circomspect/Dockerfile
+++ b/images/circomspect/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:lts-bookworm-slim
 
+ARG TAG=main
+
 # Install Rust.
 RUN apt update && apt install -y curl bash gcc git tar gzip libc++-dev
 RUN curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf > /tmp/rustup.sh \
@@ -9,7 +11,7 @@ RUN curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf > /tmp/rustup.sh \
 ENV PATH="/root/.cargo/bin:$PATH"
 
 # Install Circomspect.
-RUN git clone https://github.com/trailofbits/circomspect.git \
+RUN git clone --depth 1 --branch "${TAG}" https://github.com/trailofbits/circomspect.git \
     && cd circomspect \
     && cargo build --release \
     && cargo install --path cli

--- a/images/circomspect/test.sh
+++ b/images/circomspect/test.sh
@@ -6,10 +6,5 @@ circomspect -l INFO -v --allow CS0003 --allow CS0004 --allow CS0005 --allow CS00
 # Show help information.
 circomspect --help
 
-# Test analysis with each supported curve.
-for curve in BN254 BLS12_381 GOLDILOCKS; do
-    circomspect -c $curve --allow CS0003 --allow CS0004 --allow CS0005 --allow CS0010 --allow P1004 circuit.circom
-done
-
 # Output analysis results to a Sarif file.
 circomspect -s analysis.sarif circuit.circom

--- a/images/circomspect/test.sh
+++ b/images/circomspect/test.sh
@@ -1,14 +1,14 @@
 #! /bin/sh -e
 
 # Analyze circuit.
-circomspect -l INFO -v circuit.circom
+circomspect -l INFO -v --allow CS0004 circuit.circom
 
 # Show help information.
 circomspect --help
 
 # Test analysis with each supported curve.
 for curve in BN254 BLS12_381 GOLDILOCKS; do
-    circomspect -c $curve circuit.circom
+    circomspect -c $curve --allow CS0004 circuit.circom
 done
 
 # Output analysis results to a Sarif file.

--- a/images/circomspect/test.sh
+++ b/images/circomspect/test.sh
@@ -1,14 +1,14 @@
 #! /bin/sh -e
 
 # Analyze circuit.
-circomspect -l INFO -v --allow CS0004 circuit.circom
+circomspect -l INFO -v --allow CS0003 --allow CS0004 --allow CS0005 --allow CS0010 --allow P1004 circuit.circom
 
 # Show help information.
 circomspect --help
 
 # Test analysis with each supported curve.
 for curve in BN254 BLS12_381 GOLDILOCKS; do
-    circomspect -c $curve --allow CS0004 circuit.circom
+    circomspect -c $curve --allow CS0003 --allow CS0004 --allow CS0005 --allow CS0010 --allow P1004 circuit.circom
 done
 
 # Output analysis results to a Sarif file.

--- a/images/circomspect/test.sh
+++ b/images/circomspect/test.sh
@@ -4,4 +4,4 @@
 circomspect --help
 
 # Analyze circuit and write results to a Sarif file.
-circomspect -l INFO -v --allow CS0003 --allow CS0004 --allow CS0005 --allow CS0010 --allow P1004 -s analysis.sarif circuit.circom
+circomspect -l INFO -v --allow CS0003 --allow CS0004 --allow CS0005 --allow CS0010 --allow CS0014 --allow P1004 -s analysis.sarif circuit.circom

--- a/images/circomspect/test.sh
+++ b/images/circomspect/test.sh
@@ -1,10 +1,7 @@
 #! /bin/sh -e
 
-# Analyze circuit.
-circomspect -l INFO -v --allow CS0003 --allow CS0004 --allow CS0005 --allow CS0010 --allow P1004 circuit.circom
-
 # Show help information.
 circomspect --help
 
-# Output analysis results to a Sarif file.
-circomspect -s analysis.sarif circuit.circom
+# Analyze circuit and write results to a Sarif file.
+circomspect -l INFO -v --allow CS0003 --allow CS0004 --allow CS0005 --allow CS0010 --allow P1004 -s analysis.sarif circuit.circom

--- a/scripts/list-tags.sh
+++ b/scripts/list-tags.sh
@@ -1,0 +1,20 @@
+#! /bin/bash
+
+# Parse the arguments and log usage.
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 username/repository"
+    exit 1
+fi
+REPO_URL="https://github.com/$1.git"
+
+# Make a temporary directory to clone the repo and ensure it's cleaned up after.
+TEMP_DIR=$(mktemp -d)
+trap "rm -rf $TEMP_DIR" EXIT
+
+# Clone the repository.
+git clone --bare --depth 1 $REPO_URL $TEMP_DIR > /dev/null 2>&1
+cd $TEMP_DIR
+git fetch --depth=1 origin +refs/tags/*:refs/tags/* > /dev/null 2>&1
+
+# List and sort tags by date, from oldest to newest.
+git for-each-ref --sort=creatordate --format '%(refname:short)' refs/tags

--- a/scripts/list-tags.sh
+++ b/scripts/list-tags.sh
@@ -17,4 +17,4 @@ cd $TEMP_DIR
 git fetch --depth=1 origin +refs/tags/*:refs/tags/* > /dev/null 2>&1
 
 # List and sort tags by date, from oldest to newest.
-git for-each-ref --sort=creatordate --format '%(refname:short)' refs/tags
+git for-each-ref --sort=creatordate --format '%(refname:short)' refs/tags | grep '^v'


### PR DESCRIPTION
This adds a new github actions workflow which builds and deploys optimized images for every circomspect tag. This runs whenever a PR is delivered, and also runs nightly at 3 or 4am Eastern. The workflow can also be run manually. The PR job now deploys all of the images with a `dev` tag instead of `latest`.
