### PR TITLE
Enable circom, nargo, and snarkjs tagged builds/deploys

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -47,13 +47,19 @@ jobs:
         run: |
           echo "Building all tags for ${{ matrix.github_repository }}..."
           for tag in $(./scripts/list-tags.sh ${{ matrix.github_repository }}); do
+            echo "=================================================="
             echo "Freeing up disk space with docker prune..."
+            echo "=================================================="
             docker system prune --all --force --volumes
 
+            echo "=================================================="
             echo "Building ${{ matrix.image }}:${tag}..."
+            echo "=================================================="
             docker buildx build -f images/${{ matrix.image }}/Dockerfile --build-arg "TAG=${tag}" -t ${{ matrix.image }}:unoptimized --load images/${{ matrix.image }}/
 
+            echo "=================================================="
             echo "Optimizing ${{ matrix.image }}:${tag}..."
+            echo "=================================================="
             slim build --target ${{ matrix.image }}:unoptimized \
               --tag "sindrilabs/${{ matrix.image }}:${tag}" \
               --tag sindrilabs/${{ matrix.image }}:latest \
@@ -62,9 +68,13 @@ jobs:
               --mount "./images/${{ matrix.image }}/:/sindri/" \
               --exec "./test.sh"
 
+            echo "=================================================="
             echo "Publishing ${{ matrix.image }}:${tag}..."
+            echo "=================================================="
             docker push "sindrilabs/${{ matrix.image }}:${tag}"
           done
 
+          echo "=================================================="
           echo "Publishing ${{ matrix.image }}:latest..."
+          echo "=================================================="
           docker push sindrilabs/${{ matrix.image }}:latest

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -5,6 +5,9 @@ on:
   push:
     branches: ["main"]
 
+  # DELETE ME
+  pull_request:
+
   # Allows you to run this workflow manually from the Actions tab.
   workflow_dispatch:
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,8 +17,14 @@ jobs:
     strategy:
       matrix:
         include:
+          - image: "circom"
+            github_repository: "iden3/circom"
           - image: "circomspect"
             github_repository: "trailofbits/circomspect"
+          - image: "nargo"
+            github_repository: "noir-lang/noir"
+          - image: "snarkjs"
+            github_repository: "iden3/snarkjs"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
This adds circom, nargo, and snarkjs to the `deploy.yaml` workflow configuration.
